### PR TITLE
Fix import syntax

### DIFF
--- a/python_api.rst
+++ b/python_api.rst
@@ -12,7 +12,7 @@ Quick Example Code
 .. code-block:: python
 
     import asyncio
-    import start from beam_interactive
+    from beam_interactive import start
     import beam_interactive.proto
     import random
 


### PR DESCRIPTION
Come on... Python doesn't use ES6. :wink: 