### PR TITLE
Optimize exit sequence

### DIFF
--- a/python_api.rst
+++ b/python_api.rst
@@ -109,8 +109,6 @@ Quick Example Code
 
         conn.close()
 
-    loop.run_until_complete(connect())
-
     try:
         loop.run_until_complete(connect())
     except KeyboardInterrupt:

--- a/python_api.rst
+++ b/python_api.rst
@@ -112,7 +112,9 @@ Quick Example Code
     loop.run_until_complete(connect())
 
     try:
-        loop.run_forever()
+        loop.run_until_complete(connect())
+    except KeyboardInterrupt:
+        print("Terminated.")
     finally:
         loop.close()
 


### PR DESCRIPTION
There used to be a `try` block that would not be used, as `loop.run_until_complete(connect())` was run beforehand. That function is now moved to the `try` block itself (replacing `loop.run_forever()`), and `KeyboardInterrupt` `Exception`s are now caught, printing "Terminated." before cleanly closing the `loop`.